### PR TITLE
convert tests to Test::More

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5,4 +5,4 @@ Makefile.PL
 MANIFEST			This list of files
 META.yml
 README
-test.pl
+t/basic.t

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,14 +1,12 @@
-use Test;
-BEGIN { plan tests => 5 };
-use Text::FormatTable;
-ok(1); # If we made it this far, we're ok.
-
 use strict;
 use warnings;
 
+use Text::FormatTable;
+use Test::More;
+
 {
     my $table = Text::FormatTable->new('r| l l');
-$table->head('a', 'b', 'c');
+    $table->head('a', 'b', 'c');
     $table->rule('=');
     $table->row('this a test, a nice test', 'oh, cool, a test!', 'yep');
     $table->rule;
@@ -33,7 +31,7 @@ really|
 =================
 END
 
-    ok($is, $shouldbe);
+    is($is, $shouldbe, "basic self-test");
 }
 
 # Test behavior with ANSI-colored header
@@ -46,7 +44,11 @@ END
     $colortable->row(qw(a b c));
     my $output = $colortable->render();
     my ($rule) = ($output =~ /(=+)/);
-    ok(length($rule), length("foo bar bat"));
+    is(
+        length($rule),
+        length("foo bar bat"),
+        "length is counted without regard for color codes in header",
+    );
 }
 
 # Test behavior with ANSI-colored row data
@@ -59,16 +61,25 @@ END
     $colortable->row('a', $RED . 'b' . $RESET, 'c');
     my $output = $colortable->render();
     my ($rule) = ($output =~ /(=+)/);
-    ok(length($rule), length("foo bar bat"));
+    is(
+        length($rule),
+        length("foo bar bat"),
+        "length is counted without regard for color codes in rows",
+    );
 }
 
 # rt34546, warnings when column has zero length
 {
     my $warning;
     local $SIG{__WARN__} = sub { $warning = $_[0] };
-    
+
     my $table = Text::FormatTable->new('l l');
     $table->head('foo', q{});
     my $output = $table->render();
-    ok(not defined $warning);
+    ok(
+        ! defined $warning,
+        "no warning issued on zero-length column name",
+    );
 }
+
+done_testing;


### PR DESCRIPTION
This is more or less the standard, and has been for 10+ years.  While Test.pm will get the job done, it is much less flexible, and does not leave room for adding more separate test files.