### PR TITLE
fix behavior of color codes with wrapped cells

### DIFF
--- a/example.pl
+++ b/example.pl
@@ -1,10 +1,35 @@
+use strict;
+use warnings;
+
 use lib 'lib';
+
+use Term::ANSIColor;
 use Text::FormatTable;
-my $table = Text::FormatTable->new('r|l');
-$table->head('a', 'b');
-$table->rule('=');
-$table->row('this a test, a nice test', 'a test!');
-$table->rule;
-$table->row('you mean it\'s really a test?', 'yep');
-$table->rule('=');
-print $table->render(20);
+
+{
+  my $table = Text::FormatTable->new('r|l');
+  $table->head('a', 'b');
+  $table->rule('=');
+  $table->row('this a test, a nice test', 'a test!');
+  $table->rule;
+  $table->row('you mean it\'s really a test?', 'yep');
+  $table->rule('=');
+  print $table->render(20);
+}
+
+print "\n", "-" x 78, "\n\n";
+
+
+{
+  my $table = Text::FormatTable->new('r|l');
+  $table->head('a', 'b');
+  $table->rule('=');
+  $table->row(
+    'this a ' . colored(['bright_blue'], 'test, a nice') . ' test',
+    'a test you can count on!',
+  );
+  $table->rule;
+  $table->row('you mean it\'s really a test?', 'yep');
+  $table->rule('=');
+  print $table->render(20);
+}


### PR DESCRIPTION
 If a column contains color codes, we should keep the color contained
 to the column itself, stopping it at the column boundary and starting
 it again on the next continuation.

 This may have a more subtle bug, related to padding between end of
 data in a column and its boundary, when the color codes have added
 a background color.'